### PR TITLE
[beatsync] add admin permissions system with playback controls

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -31,6 +31,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.477.0",
     "motion": "^12.9.2",
+    "nanoid": "^5.1.5",
     "next": "15.2.1",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.236.7",

--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -121,6 +121,21 @@
   --sidebar-ring: oklch(0.439 0 0);
 }
 
+/* Dynamic viewport height class */
+.h-dvh {
+  height: 100vh; /* Fallback for older browsers */
+  height: 100dvh; /* Modern browsers auto-adjust for browser chrome */
+}
+
+/* Safe area padding utilities */
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.pb-safe-plus-4 {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 1rem);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -28,6 +28,12 @@ export const metadata: Metadata = {
     "Beatsync is an open-source, web audio player built for multi-device playback.",
   keywords: ["music", "sync", "audio", "collaboration", "real-time"],
   authors: [{ name: "Freeman Jiang" }],
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+    viewportFit: "cover",
+  },
 };
 
 export default function RootLayout({

--- a/apps/client/src/components/AudioUploaderMinimal.tsx
+++ b/apps/client/src/components/AudioUploaderMinimal.tsx
@@ -123,7 +123,9 @@ export const AudioUploaderMinimal = () => {
       onDragLeave={onDragLeave}
       onDragEnd={onDragLeave}
       onDrop={onDropEvent}
-      title={isDisabled ? "Admin-only mode - only admins can upload" : undefined}
+      title={
+        isDisabled ? "Admin-only mode - only admins can upload" : undefined
+      }
     >
       <label
         htmlFor="audio-upload"
@@ -160,7 +162,7 @@ export const AudioUploaderMinimal = () => {
                 )}
               >
                 {isDisabled
-                  ? "Admin-only mode"
+                  ? "Must be an admin to upload"
                   : "Add music to queue"}
               </div>
             )}

--- a/apps/client/src/components/AudioUploaderMinimal.tsx
+++ b/apps/client/src/components/AudioUploaderMinimal.tsx
@@ -2,9 +2,8 @@
 
 import { uploadAudioFile } from "@/lib/api";
 import { cn, trimFileName } from "@/lib/utils";
-import { useGlobalStore } from "@/store/global";
+import { useCanMutate } from "@/store/global";
 import { useRoomStore } from "@/store/room";
-import { PlaybackControlsPermissionsEnum } from "@beatsync/shared";
 import { CloudUpload, Plus } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
@@ -14,16 +13,11 @@ export const AudioUploaderMinimal = () => {
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [fileName, setFileName] = useState<string | null>(null);
-  const currentUser = useGlobalStore((state) => state.currentUser);
-  const playbackControlsPermissions = useGlobalStore(
-    (state) => state.playbackControlsPermissions
-  );
+  const canMutate = useCanMutate();
   const roomId = useRoomStore((state) => state.roomId);
   const posthog = usePostHog();
 
-  const isAdmin = currentUser?.isAdmin || false;
-  const isAdminOnly = playbackControlsPermissions === PlaybackControlsPermissionsEnum.enum.ADMIN_ONLY;
-  const isDisabled = !isAdmin && isAdminOnly;
+  const isDisabled = !canMutate;
 
   const handleFileUpload = async (file: File) => {
     if (isDisabled) return;

--- a/apps/client/src/components/AudioUploaderMinimal.tsx
+++ b/apps/client/src/components/AudioUploaderMinimal.tsx
@@ -173,7 +173,7 @@ export const AudioUploaderMinimal = () => {
       <input
         id="audio-upload"
         type="file"
-        accept="audio/*"
+        accept="audio/mpeg,audio/mp3,audio/wav,audio/mp4,audio/aac,audio/ogg,audio/webm,audio/flac,.mp3,.wav,.m4a,.aac,.ogg,.webm,.flac"
         onChange={onInputChange}
         disabled={isUploading || isDisabled}
         className="hidden"

--- a/apps/client/src/components/AudioUploaderMinimal.tsx
+++ b/apps/client/src/components/AudioUploaderMinimal.tsx
@@ -173,7 +173,7 @@ export const AudioUploaderMinimal = () => {
       <input
         id="audio-upload"
         type="file"
-        accept="audio/mpeg,audio/mp3,audio/wav,audio/mp4,audio/aac,audio/ogg,audio/webm,audio/flac,.mp3,.wav,.m4a,.aac,.ogg,.webm,.flac"
+        accept="audio/mpeg,audio/mp3,audio/wav,audio/aac,audio/ogg,audio/webm,audio/flac,.mp3,.wav,.m4a,.aac,.ogg,.webm,.flac"
         onChange={onInputChange}
         disabled={isUploading || isDisabled}
         className="hidden"

--- a/apps/client/src/components/AudioUploaderMinimal.tsx
+++ b/apps/client/src/components/AudioUploaderMinimal.tsx
@@ -112,7 +112,7 @@ export const AudioUploaderMinimal = () => {
       className={cn(
         "border border-neutral-700/50 rounded-md mx-2 transition-all overflow-hidden",
         notAdmin
-          ? "bg-neutral-800/20 opacity-50 cursor-not-allowed"
+          ? "bg-neutral-800/20 opacity-50"
           : "bg-neutral-800/30 hover:bg-neutral-800/50",
         isDragging && !notAdmin
           ? "outline outline-primary-400 outline-dashed"
@@ -127,10 +127,7 @@ export const AudioUploaderMinimal = () => {
     >
       <label
         htmlFor="audio-upload"
-        className={cn(
-          "block w-full",
-          notAdmin ? "cursor-not-allowed" : "cursor-pointer"
-        )}
+        className={cn("block w-full", notAdmin ? "" : "cursor-pointer")}
       >
         <div className="p-3 flex items-center gap-3">
           <div

--- a/apps/client/src/components/Queue.tsx
+++ b/apps/client/src/components/Queue.tsx
@@ -5,7 +5,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn, extractFileNameFromUrl, formatTime } from "@/lib/utils";
-import { useGlobalStore } from "@/store/global";
+import { useCanMutate, useGlobalStore } from "@/store/global";
 import { AudioSourceType } from "@beatsync/shared";
 import { MoreHorizontal, Pause, Play, UploadCloud } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -23,8 +23,10 @@ export const Queue = ({ className, ...rest }: React.ComponentProps<"div">) => {
   const broadcastPause = useGlobalStore((state) => state.broadcastPause);
   const isPlaying = useGlobalStore((state) => state.isPlaying);
   const getAudioDuration = useGlobalStore((state) => state.getAudioDuration);
+  const canMutate = useCanMutate();
 
   const handleItemClick = (source: AudioSourceType) => {
+    if (!canMutate) return;
     if (source.url === selectedAudioId) {
       if (isPlaying) {
         broadcastPause();
@@ -70,7 +72,8 @@ export const Queue = ({ className, ...rest }: React.ComponentProps<"div">) => {
                     "flex items-center pl-2 pr-4 py-3 rounded-md group transition-colors select-none",
                     isSelected
                       ? "text-white hover:bg-neutral-700/20"
-                      : "text-neutral-300 hover:bg-neutral-700/20"
+                      : "text-neutral-300 hover:bg-neutral-700/20",
+                    !canMutate && "text-white/50"
                   )}
                   onClick={() => handleItemClick(source)}
                 >

--- a/apps/client/src/components/dashboard/AudioControls.tsx
+++ b/apps/client/src/components/dashboard/AudioControls.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useGlobalStore } from "@/store/global";
+import { useGlobalStore, useCanMutate } from "@/store/global";
 import { Construction, Orbit, Sparkles } from "lucide-react";
 import { motion } from "motion/react";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "../ui/button";
+import { cn } from "@/lib/utils";
 
 export const AudioControls = () => {
   const posthog = usePostHog();
+  const canMutate = useCanMutate();
   const startSpatialAudio = useGlobalStore((state) => state.startSpatialAudio);
   const stopSpatialAudio = useGlobalStore(
     (state) => state.sendStopSpatialAudio
@@ -15,11 +17,13 @@ export const AudioControls = () => {
   const isLoadingAudio = useGlobalStore((state) => state.isInitingSystem);
 
   const handleStartSpatialAudio = () => {
+    if (!canMutate) return;
     startSpatialAudio();
     posthog.capture("start_spatial_audio");
   };
 
   const handleStopSpatialAudio = () => {
+    if (!canMutate) return;
     stopSpatialAudio();
     posthog.capture("stop_spatial_audio");
   };
@@ -32,7 +36,10 @@ export const AudioControls = () => {
       </div>
 
       <div className="space-y-2">
-        <motion.div className="bg-neutral-800/20 rounded-md p-3 hover:bg-neutral-800/30 transition-colors">
+        <motion.div className={cn(
+          "bg-neutral-800/20 rounded-md p-3 hover:bg-neutral-800/30 transition-colors",
+          !canMutate && "opacity-50"
+        )}>
           <div className="flex justify-between items-center">
             <div className="text-xs text-neutral-300 flex items-center gap-1.5">
               <Orbit className="h-3 w-3 text-primary-500" />
@@ -43,7 +50,7 @@ export const AudioControls = () => {
                 className="text-xs px-3 py-1 h-auto bg-primary-600/80 hover:bg-primary-600 text-white"
                 size="sm"
                 onClick={handleStartSpatialAudio}
-                disabled={isLoadingAudio}
+                disabled={isLoadingAudio || !canMutate}
               >
                 Start
               </Button>
@@ -51,7 +58,7 @@ export const AudioControls = () => {
                 className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white"
                 size="sm"
                 onClick={handleStopSpatialAudio}
-                disabled={isLoadingAudio}
+                disabled={isLoadingAudio || !canMutate}
               >
                 Stop
               </Button>

--- a/apps/client/src/components/dashboard/AudioControls.tsx
+++ b/apps/client/src/components/dashboard/AudioControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useGlobalStore } from "@/store/global";
-import { Construction, Orbit } from "lucide-react";
+import { Construction, Orbit, Sparkles } from "lucide-react";
 import { motion } from "motion/react";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "../ui/button";
@@ -25,19 +25,13 @@ export const AudioControls = () => {
   };
 
   return (
-    <motion.div className="px-4 space-y-3 py-3">
-      <h2
-        className={`text-xs font-medium uppercase tracking-wide ${
-          isLoadingAudio ? "text-neutral-500" : "text-neutral-400"
-        }`}
-      >
-        Audio Effects{" "}
-        {isLoadingAudio && (
-          <span className="text-xs opacity-70">(loading...)</span>
-        )}
-      </h2>
+    <motion.div className="px-4 space-y-2 py-3 mt-1">
+      <div className="flex items-center gap-2 font-medium">
+        <Sparkles size={18} />
+        <span>Audio Effects</span>
+      </div>
 
-      <div className="space-y-3">
+      <div className="space-y-2">
         <motion.div className="bg-neutral-800/20 rounded-md p-3 hover:bg-neutral-800/30 transition-colors">
           <div className="flex justify-between items-center">
             <div className="text-xs text-neutral-300 flex items-center gap-1.5">
@@ -64,7 +58,7 @@ export const AudioControls = () => {
             </div>
           </div>
         </motion.div>
-        <div className="bg-neutral-800/20 rounded-md p-3 hover:bg-neutral-800/30 transition-colors">
+        <div className="bg-neutral-800/20 rounded-md p-2.5 hover:bg-neutral-800/30 transition-colors">
           <div className="flex flex-col gap-2">
             <div className="text-xs text-neutral-500 flex items-center gap-1.5">
               <Construction className="h-3 w-3 text-neutral-400" />

--- a/apps/client/src/components/dashboard/Bottom.tsx
+++ b/apps/client/src/components/dashboard/Bottom.tsx
@@ -3,7 +3,7 @@ import { Player } from "../room/Player";
 
 export const Bottom = () => {
   return (
-    <motion.div className="flex-shrink-0 border-t border-neutral-800/50 bg-neutral-900/10 backdrop-blur-lg p-4 shadow-[0_-5px_15px_rgba(0,0,0,0.1)] z-10 relative">
+    <motion.div className="flex-shrink-0 border-t border-neutral-800/50 bg-neutral-900/10 backdrop-blur-lg p-4 pb-safe-plus-4 shadow-[0_-5px_15px_rgba(0,0,0,0.1)] z-10 relative">
       <div className="max-w-3xl mx-auto">
         <Player />
       </div>

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -50,7 +50,7 @@ const ConnectedUserItem = memo<ConnectedUserItemProps>(
           </Avatar>
           {/* Admin crown indicator */}
           {client.isAdmin && (
-            <div className="absolute -top-0.5 -right-0.5 bg-yellow-500 rounded-full p-0.5">
+            <div className="absolute -top-1 -right-0.5 bg-yellow-500 rounded-full p-0.5">
               <Crown
                 className="h-2.5 w-2.5 text-yellow-900"
                 fill="currentColor"
@@ -148,18 +148,18 @@ export const ConnectedUsersList = () => {
           </div>
         ) : (
           <div className="space-y-2">
-            <div className="flex mb-4 justify-end">
-              {/* <Button
+            {/* <div className="flex mb-4 justify-end">
+              <Button
                 className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer w-full"
                 size="sm"
                 onClick={() => reorderClient(userId)}
               >
                 <ArrowUp className="size-4" /> Move to Top
-              </Button> */}
-            </div>
+              </Button>
+            </div> */}
 
             {/* List of connected users - Constrained height */}
-            <div className="relative">
+            <div className="relative mt-2.5">
               <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20">
                 {clientsWithData.map(({ client, isCurrentUser }) => (
                   <ConnectedUserItem

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -1,0 +1,180 @@
+"use client";
+import { cn } from "@/lib/utils";
+import { useGlobalStore } from "@/store/global";
+import { useRoomStore } from "@/store/room";
+import { ClientType } from "@beatsync/shared";
+import { Crown, MoreVertical, Users } from "lucide-react";
+import { motion } from "motion/react";
+import { memo, useMemo } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+
+interface ConnectedUserItemProps {
+  client: ClientType;
+  isCurrentUser: boolean;
+  isAdmin: boolean;
+  onSetAdmin: (clientId: string, isAdmin: boolean) => void;
+}
+
+// Separate connected user list item component
+const ConnectedUserItem = memo<ConnectedUserItemProps>(
+  ({ client, isCurrentUser, isAdmin, onSetAdmin }) => {
+    return (
+      <motion.div
+        className={cn(
+          "flex items-center gap-2 p-1.5 rounded-md transition-all duration-300 text-sm",
+          isCurrentUser ? "bg-primary-400/10" : "bg-transparent"
+        )}
+        initial={{ opacity: 0.8 }}
+        animate={{
+          opacity: 1,
+          scale: 1,
+        }}
+        transition={{ duration: 0.3 }}
+      >
+        <div className="relative">
+          <Avatar className="h-8 w-8">
+            <AvatarImage />
+            <AvatarFallback
+              className={isCurrentUser ? "bg-primary-600" : "bg-neutral-600"}
+            >
+              {client.username.slice(0, 2).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          {/* Admin crown indicator */}
+          {client.isAdmin && (
+            <div className="absolute -top-0.5 -right-0.5 bg-yellow-500 rounded-full p-0.5">
+              <Crown
+                className="h-2.5 w-2.5 text-yellow-900"
+                fill="currentColor"
+              />
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col min-w-0">
+          <span className="text-xs font-medium truncate">
+            {client.username}
+          </span>
+        </div>
+        <Badge
+          variant={isCurrentUser ? "default" : "outline"}
+          className={cn(
+            "ml-auto text-xs shrink-0 min-w-[60px] text-center py-0 h-5",
+            isCurrentUser ? "bg-primary-600 text-primary-50" : ""
+          )}
+        >
+          {isCurrentUser ? "You" : "Connected"}
+        </Badge>
+        {/* Admin controls dropdown - only show if current user is admin and not targeting self */}
+        {isAdmin && !isCurrentUser && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0 hover:bg-neutral-700/50"
+              >
+                <MoreVertical className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              {client.isAdmin ? (
+                <DropdownMenuItem
+                  onClick={() => onSetAdmin(client.clientId, false)}
+                  className="text-xs"
+                >
+                  <Crown className="h-3 w-3 mr-2 text-red-500" />
+                  Remove Admin
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  onClick={() => onSetAdmin(client.clientId, true)}
+                  className="text-xs"
+                >
+                  <Crown className="h-3 w-3 mr-2 text-green-500" />
+                  Make Admin
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </motion.div>
+    );
+  }
+);
+ConnectedUserItem.displayName = "ConnectedUserItem";
+
+export const ConnectedUsersList = () => {
+  const userId = useRoomStore((state) => state.userId);
+  const clients = useGlobalStore((state) => state.connectedClients);
+  // const reorderClient = useGlobalStore((state) => state.reorderClient);
+  const setAdminStatus = useGlobalStore((state) => state.setAdminStatus);
+
+  // Get current user from global store
+  const currentUser = useGlobalStore((state) => state.currentUser);
+  const isCurrentUserAdmin = currentUser?.isAdmin || false;
+
+  // Memoize client data to avoid unnecessary recalculations
+  const clientsWithData = useMemo(() => {
+    return clients.map((client) => {
+      const isCurrentUser = client.clientId === userId;
+      return { client, isCurrentUser };
+    });
+  }, [clients, userId]);
+
+  return (
+    <div className="">
+      <div className="flex items-center justify-between px-4 pt-3">
+        <h2 className="text-xs font-medium uppercase tracking-wider text-neutral-500 flex items-center gap-2">
+          <Users className="h-3.5 w-3.5" />
+          <span>Connected Users</span>
+        </h2>
+        <span className="text-xs font-medium text-neutral-400">
+          {clients.length}
+        </span>
+      </div>
+
+      <div className="px-4 pb-3">
+        {clients.length === 0 ? (
+          <div className="text-center py-8 text-neutral-500 text-xs">
+            No other users connected
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex mb-4 justify-end">
+              {/* <Button
+                className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer w-full"
+                size="sm"
+                onClick={() => reorderClient(userId)}
+              >
+                <ArrowUp className="size-4" /> Move to Top
+              </Button> */}
+            </div>
+
+            {/* List of connected users - Constrained height */}
+            <div className="relative">
+              <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20">
+                {clientsWithData.map(({ client, isCurrentUser }) => (
+                  <ConnectedUserItem
+                    key={client.clientId}
+                    client={client}
+                    isCurrentUser={isCurrentUser}
+                    isAdmin={isCurrentUserAdmin}
+                    onSetAdmin={setAdminStatus}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -158,7 +158,7 @@ export const ConnectedUsersList = () => {
 
             {/* List of connected users - Constrained height */}
             <div className="relative mt-2.5">
-              <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20">
+              <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20 -mx-1">
                 {clientsWithData.map(({ client, isCurrentUser }) => (
                   <ConnectedUserItem
                     key={client.clientId}

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -1,7 +1,7 @@
 "use client";
+import { useClientId } from "@/hooks/useClientId";
 import { cn } from "@/lib/utils";
 import { useGlobalStore } from "@/store/global";
-import { useRoomStore } from "@/store/room";
 import { ClientType } from "@beatsync/shared";
 import { Crown, MoreVertical, Users } from "lucide-react";
 import { motion } from "motion/react";
@@ -112,7 +112,7 @@ const ConnectedUserItem = memo<ConnectedUserItemProps>(
 ConnectedUserItem.displayName = "ConnectedUserItem";
 
 export const ConnectedUsersList = () => {
-  const userId = useRoomStore((state) => state.userId);
+  const { clientId } = useClientId();
   const clients = useGlobalStore((state) => state.connectedClients);
   // const reorderClient = useGlobalStore((state) => state.reorderClient);
   const setAdminStatus = useGlobalStore((state) => state.setAdminStatus);
@@ -124,10 +124,10 @@ export const ConnectedUsersList = () => {
   // Memoize client data to avoid unnecessary recalculations
   const clientsWithData = useMemo(() => {
     return clients.map((client) => {
-      const isCurrentUser = client.clientId === userId;
+      const isCurrentUser = client.clientId === clientId;
       return { client, isCurrentUser };
     });
-  }, [clients, userId]);
+  }, [clients, clientId]);
 
   return (
     <div className="">

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -136,9 +136,7 @@ export const ConnectedUsersList = () => {
           <Users className="h-3.5 w-3.5" />
           <span>Connected Users</span>
         </h2>
-        <span className="text-xs font-medium text-neutral-400">
-          {clients.length}
-        </span>
+        <Badge variant="outline">{clients.length}</Badge>
       </div>
 
       <div className="px-4 pb-3">

--- a/apps/client/src/components/dashboard/ConnectedUsersList.tsx
+++ b/apps/client/src/components/dashboard/ConnectedUsersList.tsx
@@ -146,16 +146,6 @@ export const ConnectedUsersList = () => {
           </div>
         ) : (
           <div className="space-y-2">
-            {/* <div className="flex mb-4 justify-end">
-              <Button
-                className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer w-full"
-                size="sm"
-                onClick={() => reorderClient(userId)}
-              >
-                <ArrowUp className="size-4" /> Move to Top
-              </Button>
-            </div> */}
-
             {/* List of connected users - Constrained height */}
             <div className="relative mt-2.5">
               <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20 -mx-1">

--- a/apps/client/src/components/dashboard/Dashboard.tsx
+++ b/apps/client/src/components/dashboard/Dashboard.tsx
@@ -67,7 +67,7 @@ export const Dashboard = ({ roomId }: DashboardProps) => {
                   value="library"
                   className="flex-1 data-[state=active]:bg-white/5 data-[state=active]:shadow-none rounded-none text-xs h-full gap-1 text-neutral-400 data-[state=active]:text-white transition-all duration-200"
                 >
-                  <Library size={16} /> Library
+                  <Library size={16} /> Session
                 </TabsTrigger>
                 <TabsTrigger
                   value="queue"

--- a/apps/client/src/components/dashboard/Dashboard.tsx
+++ b/apps/client/src/components/dashboard/Dashboard.tsx
@@ -16,7 +16,9 @@ interface DashboardProps {
 export const Dashboard = ({ roomId }: DashboardProps) => {
   const isSynced = useGlobalStore((state) => state.isSynced);
   const isLoadingAudio = useGlobalStore((state) => state.isInitingSystem);
-  const hasUserStartedSystem = useGlobalStore((state) => state.hasUserStartedSystem);
+  const hasUserStartedSystem = useGlobalStore(
+    (state) => state.hasUserStartedSystem
+  );
 
   const isReady = isSynced && !isLoadingAudio;
 
@@ -32,14 +34,12 @@ export const Dashboard = ({ roomId }: DashboardProps) => {
   };
 
   return (
-    <div className="w-full h-screen flex flex-col text-white bg-neutral-950">
+    <div className="w-full h-dvh flex flex-col text-white bg-neutral-950">
       {/* Top bar: Fixed height */}
       <TopBar roomId={roomId} />
 
       {/* Show SyncProgress during reconnection (when user has already started but lost sync) */}
-      {!isSynced && hasUserStartedSystem && !isLoadingAudio && (
-        <SyncProgress />
-      )}
+      {!isSynced && hasUserStartedSystem && !isLoadingAudio && <SyncProgress />}
 
       {isReady && (
         <motion.div

--- a/apps/client/src/components/dashboard/Dashboard.tsx
+++ b/apps/client/src/components/dashboard/Dashboard.tsx
@@ -52,7 +52,7 @@ export const Dashboard = ({ roomId }: DashboardProps) => {
           <div className="hidden lg:flex lg:flex-1 lg:overflow-hidden min-h-0">
             <Left className="flex" />
             <Main />
-            <Right className="flex lg:w-80 lg:flex-shrink-0" />
+            <Right className="flex lg:flex-shrink-0" />
           </div>
 
           {/* --- MOBILE LAYOUT (< lg) --- */}

--- a/apps/client/src/components/dashboard/Left.tsx
+++ b/apps/client/src/components/dashboard/Left.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { Library, Search } from "lucide-react";
+import { useRoomStore } from "@/store/room";
+import { Hash, Search } from "lucide-react";
 import { motion } from "motion/react";
 import { AudioUploaderMinimal } from "../AudioUploaderMinimal";
 import { Button } from "../ui/button";
@@ -26,6 +27,8 @@ export const Left = ({ className }: LeftProps) => {
   //   }
   // };
 
+  const roomId = useRoomStore((state) => state.roomId);
+
   return (
     <motion.div
       className={cn(
@@ -44,24 +47,16 @@ export const Left = ({ className }: LeftProps) => {
 
       <Separator className="bg-neutral-800/50" /> */}
 
-      {/* Your Library Section */}
-      <h2 className="text-base font-bold select-none px-4 py-3 -mb-2">
-        Your Library
-      </h2>
-
       {/* Navigation menu */}
-      <motion.div className="px-3.5 space-y-1.5 py-2">
-        <Button
-          className="w-full flex justify-start gap-3 py-2 text-white font-medium bg-white/10 hover:bg-white/15 rounded-md text-xs transition-colors duration-200"
-          variant="ghost"
-        >
-          <Library className="h-4 w-4" />
-          <span>Default Library</span>
-        </Button>
+      <motion.div className="px-3.5 space-y-2.5 py-2 mt-1">
+        <div className="flex items-center gap-2 font-medium">
+          <Hash size={18} />
+          <span>Room {roomId}</span>
+        </div>
 
-        <a href="https://cobalt.tools/" target="_blank">
+        <a href="https://ytmp3.cx/" target="_blank">
           <Button
-            className="w-full flex justify-start gap-3 py-2 text-white font-medium bg-white/10 hover:bg-white/15 rounded-md text-xs transition-colors duration-200 cursor-pointer"
+            className="w-full flex justify-start gap-3 py-2 text-white font-medium bg-white/10 hover:bg-white/15 rounded-lg text-xs transition-colors duration-200 cursor-pointer"
             variant="ghost"
           >
             <Search className="h-4 w-4" />

--- a/apps/client/src/components/dashboard/Left.tsx
+++ b/apps/client/src/components/dashboard/Left.tsx
@@ -28,7 +28,7 @@ export const Left = ({ className }: LeftProps) => {
   return (
     <motion.div
       className={cn(
-        "w-full lg:w-80 lg:flex-shrink-0 border-l border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col pb-4 lg:pb-0 text-sm space-y-1 overflow-y-auto pr-2 flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
+        "w-full lg:w-80 lg:flex-shrink-0 border-l border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col pb-4 lg:pb-0 text-sm space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
         className
       )}
     >

--- a/apps/client/src/components/dashboard/Left.tsx
+++ b/apps/client/src/components/dashboard/Left.tsx
@@ -7,6 +7,7 @@ import { AudioUploaderMinimal } from "../AudioUploaderMinimal";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
 import { ConnectedUsersList } from "./ConnectedUsersList";
+import { PlaybackPermissions } from "./PlaybackPermissions";
 
 interface LeftProps {
   className?: string;
@@ -71,23 +72,22 @@ export const Left = ({ className }: LeftProps) => {
 
       <Separator className="bg-neutral-800/50" />
 
+      <PlaybackPermissions />
+
+      <Separator className="bg-neutral-800/50" />
+
       {/* Connected Users List */}
       <ConnectedUsersList />
 
-      <Separator className="bg-neutral-800/50" />
+      {/* Playback Permissions */}
+
+      {/* <Separator className="bg-neutral-800/50" /> */}
 
       {/* Tips Section */}
       <motion.div className="mt-auto pb-4 pt-2 text-neutral-400">
         <div className="flex flex-col gap-2 p-4 border-t border-neutral-800/50">
           <h5 className="text-xs font-medium text-neutral-300">Tips</h5>
           <ul className="list-disc list-outside pl-4 space-y-1.5">
-            <li className="text-xs leading-relaxed">
-              Works best with multiple devices IRL in the same space.
-            </li>
-            <li className="text-xs leading-relaxed">
-              If audio gets de-synced, pause, play / full sync and try again or
-              refresh.
-            </li>
             <li className="text-xs leading-relaxed">
               {"Play on speaker directly. Don't use Bluetooth."}
             </li>

--- a/apps/client/src/components/dashboard/Left.tsx
+++ b/apps/client/src/components/dashboard/Left.tsx
@@ -6,7 +6,7 @@ import { motion } from "motion/react";
 import { AudioUploaderMinimal } from "../AudioUploaderMinimal";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
-import { AudioControls } from "./AudioControls";
+import { ConnectedUsersList } from "./ConnectedUsersList";
 
 interface LeftProps {
   className?: string;
@@ -28,9 +28,7 @@ export const Left = ({ className }: LeftProps) => {
   return (
     <motion.div
       className={cn(
-        "w-full lg:w-72 flex-shrink-0 border-r border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col h-full text-sm",
-        "scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
-        "overflow-y-auto",
+        "w-full lg:w-80 lg:flex-shrink-0 border-l border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col pb-4 lg:pb-0 text-sm space-y-1 overflow-y-auto pr-2 flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
         className
       )}
     >
@@ -45,6 +43,7 @@ export const Left = ({ className }: LeftProps) => {
 
       <Separator className="bg-neutral-800/50" /> */}
 
+      {/* Your Library Section */}
       <h2 className="text-base font-bold select-none px-4 py-3 -mb-2">
         Your Library
       </h2>
@@ -72,8 +71,10 @@ export const Left = ({ className }: LeftProps) => {
 
       <Separator className="bg-neutral-800/50" />
 
-      {/* Audio Controls */}
-      <AudioControls />
+      {/* Connected Users List */}
+      <ConnectedUsersList />
+
+      <Separator className="bg-neutral-800/50" />
 
       {/* Tips Section */}
       <motion.div className="mt-auto pb-4 pt-2 text-neutral-400">

--- a/apps/client/src/components/dashboard/PlaybackPermissions.tsx
+++ b/apps/client/src/components/dashboard/PlaybackPermissions.tsx
@@ -81,7 +81,7 @@ export const PlaybackPermissions = () => {
           {/* Everyone Option */}
           <div
             className={cn(
-              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200",
+              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200 h-full",
               !isAdminOnly ? "text-white" : "text-neutral-400"
             )}
           >
@@ -92,7 +92,7 @@ export const PlaybackPermissions = () => {
           {/* Admin Only Option */}
           <div
             className={cn(
-              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200",
+              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200 h-full",
               isAdminOnly ? "text-white" : "text-neutral-400"
             )}
           >

--- a/apps/client/src/components/dashboard/PlaybackPermissions.tsx
+++ b/apps/client/src/components/dashboard/PlaybackPermissions.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useGlobalStore } from "@/store/global";
+import { sendWSRequest } from "@/utils/ws";
+import {
+  ClientActionEnum,
+  PlaybackControlsPermissionsEnum,
+} from "@beatsync/shared";
+import { Shield, Users } from "lucide-react";
+import { motion } from "motion/react";
+
+export const PlaybackPermissions = () => {
+  const currentUser = useGlobalStore((state) => state.currentUser);
+  const socket = useGlobalStore((state) => state.socket);
+  const playbackControlsPermissions = useGlobalStore(
+    (state) => state.playbackControlsPermissions
+  );
+
+  // Only show if socket is connected
+  if (!socket) {
+    return null;
+  }
+
+  const isAdmin = currentUser?.isAdmin || false;
+
+  const isAdminOnly =
+    playbackControlsPermissions ===
+    PlaybackControlsPermissionsEnum.enum.ADMIN_ONLY;
+
+  const handleToggle = () => {
+    const newPermission = isAdminOnly
+      ? PlaybackControlsPermissionsEnum.enum.EVERYONE
+      : PlaybackControlsPermissionsEnum.enum.ADMIN_ONLY;
+
+    sendWSRequest({
+      ws: socket,
+      request: {
+        type: ClientActionEnum.enum.SET_PLAYBACK_CONTROLS,
+        permissions: newPermission,
+      },
+    });
+  };
+
+  return (
+    <div className="">
+      <div className="flex items-center justify-between px-4 pt-3">
+        <h2 className="text-xs font-medium uppercase tracking-wider text-neutral-500 flex items-center gap-2">
+          <Shield className="h-3.5 w-3.5" />
+          <span>Playback Permissions</span>
+        </h2>
+      </div>
+
+      <div className="px-4 pb-3">
+        {/* Toggle Container */}
+        <button
+          onClick={isAdmin ? handleToggle : undefined}
+          disabled={!isAdmin}
+          className={cn(
+            "relative flex w-full h-8 bg-neutral-800 rounded-lg p-0.5 mt-2.5",
+            isAdmin ? "cursor-pointer" : "opacity-75"
+          )}
+        >
+          {/* Sliding Background */}
+          <motion.div
+            className={cn(
+              "absolute inset-y-0.5 w-1/2 transition-colors duration-300 rounded-lg",
+              isAdminOnly ? "bg-yellow-600" : "bg-green-600"
+            )}
+            initial={false}
+            animate={{
+              x: isAdminOnly ? "calc(100% - 4px)" : 0,
+            }}
+            transition={{
+              type: "spring",
+              stiffness: 700,
+              damping: 40,
+            }}
+          />
+
+          {/* Everyone Option */}
+          <div
+            className={cn(
+              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200",
+              !isAdminOnly ? "text-white" : "text-neutral-400"
+            )}
+          >
+            <Users className="h-3 w-3" />
+            <span>Everyone</span>
+          </div>
+
+          {/* Admin Only Option */}
+          <div
+            className={cn(
+              "relative z-10 flex-1 flex items-center justify-center gap-1.5 text-xs font-medium transition-colors duration-200",
+              isAdminOnly ? "text-white" : "text-neutral-400"
+            )}
+          >
+            <Shield className="h-3 w-3" />
+            <span>Admin Only</span>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/components/dashboard/PlaybackPermissions.tsx
+++ b/apps/client/src/components/dashboard/PlaybackPermissions.tsx
@@ -7,7 +7,7 @@ import {
   ClientActionEnum,
   PlaybackControlsPermissionsEnum,
 } from "@beatsync/shared";
-import { Shield, Users } from "lucide-react";
+import { Crown, Play, Users } from "lucide-react";
 import { motion } from "motion/react";
 
 export const PlaybackPermissions = () => {
@@ -46,7 +46,7 @@ export const PlaybackPermissions = () => {
     <div className="">
       <div className="flex items-center justify-between px-4 pt-3">
         <h2 className="text-xs font-medium uppercase tracking-wider text-neutral-500 flex items-center gap-2">
-          <Shield className="h-3.5 w-3.5" />
+          <Play className="h-3.5 w-3.5" />
           <span>Playback Permissions</span>
         </h2>
       </div>
@@ -57,7 +57,7 @@ export const PlaybackPermissions = () => {
           onClick={isAdmin ? handleToggle : undefined}
           disabled={!isAdmin}
           className={cn(
-            "relative flex w-full h-8 bg-neutral-800 rounded-lg p-0.5 mt-2.5",
+            "relative flex w-full h-8 bg-neutral-800 rounded-lg p-0.5 mt-2.5 focus:outline-none",
             isAdmin ? "cursor-pointer" : "opacity-75"
           )}
         >
@@ -96,8 +96,8 @@ export const PlaybackPermissions = () => {
               isAdminOnly ? "text-white" : "text-neutral-400"
             )}
           >
-            <Shield className="h-3 w-3" />
-            <span>Admin Only</span>
+            <Crown className="h-3 w-3" />
+            <span>Admins</span>
           </div>
         </button>
       </div>

--- a/apps/client/src/components/dashboard/Right.tsx
+++ b/apps/client/src/components/dashboard/Right.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { Info } from "lucide-react";
 import { motion } from "motion/react";
 import { UserGrid } from "../room/UserGrid";
+import { AudioControls } from "./AudioControls";
 
 interface RightProps {
   className?: string;
@@ -15,8 +16,15 @@ export const Right = ({ className }: RightProps) => {
         className
       )}
     >
-      <motion.div className="flex-1">
-        <UserGrid />
+      {/* Spatial Audio Controls */}
+      <motion.div className="flex-1 flex flex-col">
+        {/* Spatial Audio Grid */}
+        <div className="flex-1">
+          <UserGrid />
+        </div>
+
+        {/* Audio Effects Controls */}
+        <AudioControls />
       </motion.div>
 
       <motion.div className="flex flex-col gap-3 px-4 py-3 mt-1 bg-neutral-800/30 rounded-lg mx-3 mb-3 text-neutral-400">
@@ -33,7 +41,7 @@ export const Right = ({ className }: RightProps) => {
             </p>
             <p className="text-xs leading-relaxed mt-3">
               {
-                "Drag the headphone icon around and hear how the volume changes on each device. Isn't it cool!"
+                "Drag the headphone icon around and hear how the volume changes on each device."
               }
             </p>
           </div>

--- a/apps/client/src/components/dashboard/Right.tsx
+++ b/apps/client/src/components/dashboard/Right.tsx
@@ -33,13 +33,8 @@ export const Right = ({ className }: RightProps) => {
               What is this?
             </h5>
             <p className="text-xs leading-relaxed">
-              This grid simulates a spatial audio environment. The headphone
-              icon (🎧) is a listening source. The circles represent other
-              devices in the room.
-            </p>
-            <p className="text-xs leading-relaxed mt-3">
               {
-                "Drag the headphone icon around and hear how the volume changes on each device."
+                "This grid simulates a spatial audio environment. Drag the listening source around and hear how the volume changes on each device. Works best in person."
               }
             </p>
           </div>

--- a/apps/client/src/components/dashboard/Right.tsx
+++ b/apps/client/src/components/dashboard/Right.tsx
@@ -12,16 +12,14 @@ export const Right = ({ className }: RightProps) => {
   return (
     <motion.div
       className={cn(
-        "w-full lg:w-80 lg:flex-shrink-0 border-l border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col pb-4 lg:pb-0 text-sm space-y-1 overflow-y-auto pr-2 flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
+        "w-full lg:w-80 lg:flex-shrink-0 border-l border-neutral-800/50 bg-neutral-900/50 backdrop-blur-md flex flex-col pb-4 lg:pb-0 text-sm space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20",
         className
       )}
     >
       {/* Spatial Audio Controls */}
       <motion.div className="flex-1 flex flex-col">
         {/* Spatial Audio Grid */}
-        <div className="flex-1">
-          <UserGrid />
-        </div>
+        <UserGrid />
 
         {/* Audio Effects Controls */}
         <AudioControls />

--- a/apps/client/src/components/room/Player.tsx
+++ b/apps/client/src/components/room/Player.tsx
@@ -1,6 +1,6 @@
 import { cn, formatTime } from "@/lib/utils";
 
-import { useGlobalStore, useCanMutate } from "@/store/global";
+import { useCanMutate, useGlobalStore } from "@/store/global";
 import {
   Pause,
   Play,
@@ -75,12 +75,15 @@ export const Player = () => {
   }, [isPlaying, getCurrentTrackPosition, isDragging]);
 
   // Handle slider change
-  const handleSliderChange = useCallback((value: number[]) => {
-    if (!canMutate) return;
-    const position = value[0];
-    setIsDragging(true);
-    setSliderPosition(position);
-  }, [canMutate]);
+  const handleSliderChange = useCallback(
+    (value: number[]) => {
+      if (!canMutate) return;
+      const position = value[0];
+      setIsDragging(true);
+      setSliderPosition(position);
+    },
+    [canMutate]
+  );
 
   // Handle slider release - seek to that position
   const handleSliderCommit = useCallback(
@@ -176,7 +179,9 @@ export const Player = () => {
         )
       ) {
         e.preventDefault();
-        handlePlay();
+        if (canMutate) {
+          handlePlay();
+        }
       }
     };
 

--- a/apps/client/src/components/room/RoomInfo.tsx
+++ b/apps/client/src/components/room/RoomInfo.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useClientId } from "@/hooks/useClientId";
 import { useRoomStore } from "@/store/room";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 
@@ -6,7 +7,7 @@ export const RoomInfo = () => {
   // Get room information directly from the store
   const roomId = useRoomStore((state) => state.roomId);
   const username = useRoomStore((state) => state.username);
-  const userId = useRoomStore((state) => state.userId);
+  const { clientId } = useClientId();
 
   return (
     <Card className="w-full md:w-2/3">
@@ -25,7 +26,7 @@ export const RoomInfo = () => {
           </div>
           <div className="flex flex-col">
             <span className="text-sm text-muted-foreground">User ID</span>
-            <span className="font-medium truncate">{userId}</span>
+            <span className="font-medium truncate">{clientId}</span>
           </div>
         </div>
       </CardContent>

--- a/apps/client/src/components/room/SpatialAudioBackground.tsx
+++ b/apps/client/src/components/room/SpatialAudioBackground.tsx
@@ -1,14 +1,16 @@
 "use client";
+import { useClientId } from "@/hooks/useClientId";
 import { useGlobalStore } from "@/store/global";
-import { useRoomStore } from "@/store/room";
 import { motion } from "motion/react";
 
 export const SpatialAudioBackground = () => {
-  const userId = useRoomStore((state) => state.userId);
+  const { clientId } = useClientId();
   const spatialConfig = useGlobalStore((state) => state.spatialConfig);
 
+  if (!clientId) return null;
+
   // Get the current user's gain value (0 to 1), default to 0 if not found
-  const gain = spatialConfig?.gains[userId]?.gain ?? 0;
+  const gain = spatialConfig?.gains[clientId]?.gain || 0;
 
   // If gain is 0, don't render anything
   if (gain <= 0) return null;

--- a/apps/client/src/components/room/TopBar.tsx
+++ b/apps/client/src/components/room/TopBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { SOCIAL_LINKS } from "@/constants";
 import { MAX_NTP_MEASUREMENTS, useGlobalStore } from "@/store/global";
-import { useRoomStore } from "@/store/room";
 import { Crown, Hash, Users } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
@@ -20,11 +19,8 @@ export const TopBar = ({ roomId }: TopBarProps) => {
   const clockOffset = useGlobalStore((state) => state.offsetEstimate);
   const ntpMeasurements = useGlobalStore((state) => state.ntpMeasurements);
 
-  // Get current user ID to check admin status
-  const userId = useRoomStore((state) => state.userId);
-  const currentUser = connectedClients.find(
-    (client) => client.clientId === userId
-  );
+  // Get current user from global store to check admin status
+  const currentUser = useGlobalStore((state) => state.currentUser);
   const isAdmin = currentUser?.isAdmin || false;
 
   // Show minimal nav bar when synced and not loading

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -3,11 +3,12 @@ import { cn } from "@/lib/utils";
 import { useCanMutate, useGlobalStore } from "@/store/global";
 import { useRoomStore } from "@/store/room";
 import { ClientType, GRID } from "@beatsync/shared";
-import { Crown, HeadphonesIcon, Rotate3D } from "lucide-react";
+import { ArrowUp, Crown, HeadphonesIcon, Rotate3D } from "lucide-react";
 import { motion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GainMeter } from "../dashboard/GainMeter";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import {
   Tooltip,
@@ -124,6 +125,7 @@ export const UserGrid = () => {
   const setIsSpatialAudioEnabled = useGlobalStore(
     (state) => state.setIsSpatialAudioEnabled
   );
+  const reorderClient = useGlobalStore((state) => state.reorderClient);
 
   // Use clients from global store
   const clients = useGlobalStore((state) => state.connectedClients);
@@ -444,6 +446,16 @@ export const UserGrid = () => {
             </div>
           </>
         )}
+        <div className="flex mb-4 justify-end mt-2">
+          <Button
+            className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer w-fit disabled:opacity-50 disabled:cursor-not-allowed"
+            size="sm"
+            disabled={!canMutate}
+            onClick={() => reorderClient(userId)}
+          >
+            <ArrowUp className="size-4" /> Move to Top
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -8,7 +8,6 @@ import { motion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GainMeter } from "../dashboard/GainMeter";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import { Badge } from "../ui/badge";
 import { Switch } from "../ui/switch";
 import {
   Tooltip,
@@ -336,7 +335,6 @@ export const UserGrid = () => {
           <span>Spatial Audio</span>
         </div>
         <div className="flex items-center gap-2">
-          <Badge variant="outline">{clients.length}</Badge>
           <Switch
             checked={isSpatialAudioEnabled}
             onCheckedChange={(checked) => {

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -3,13 +3,7 @@ import { cn } from "@/lib/utils";
 import { useGlobalStore } from "@/store/global";
 import { useRoomStore } from "@/store/room";
 import { ClientType, GRID } from "@beatsync/shared";
-import {
-  ArrowUp,
-  Crown,
-  HeadphonesIcon,
-  MoreVertical,
-  Rotate3D,
-} from "lucide-react";
+import { Crown, HeadphonesIcon, Rotate3D } from "lucide-react";
 import { motion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GainMeter } from "../dashboard/GainMeter";
@@ -23,29 +17,12 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 
-// Add custom scrollbar styles
-import { Button } from "../ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
-import "./scrollbar.css";
-
 // Define prop types for components
 interface ClientAvatarProps {
   client: ClientType;
   isCurrentUser: boolean;
   animationSyncKey: number;
   isGridEnabled: boolean;
-}
-
-interface ConnectedUserItemProps {
-  client: ClientType;
-  isCurrentUser: boolean;
-  isAdmin: boolean;
-  onSetAdmin: (clientId: string, isAdmin: boolean) => void;
 }
 
 // Separate Client Avatar component for better performance
@@ -124,95 +101,6 @@ const ClientAvatar = memo<ClientAvatarProps>(
 );
 
 ClientAvatar.displayName = "ClientAvatar";
-
-// Separate connected user list item component
-const ConnectedUserItem = memo<ConnectedUserItemProps>(
-  ({ client, isCurrentUser, isAdmin, onSetAdmin }) => {
-    return (
-      <motion.div
-        className={cn(
-          "flex items-center gap-2 p-1.5 rounded-md transition-all duration-300 text-sm",
-          isCurrentUser ? "bg-primary-400/10" : "bg-transparent"
-        )}
-        initial={{ opacity: 0.8 }}
-        animate={{
-          opacity: 1,
-          scale: 1,
-        }}
-        transition={{ duration: 0.3 }}
-      >
-        <div className="relative">
-          <Avatar className="h-8 w-8">
-            <AvatarImage />
-            <AvatarFallback
-              className={isCurrentUser ? "bg-primary-600" : "bg-neutral-600"}
-            >
-              {client.username.slice(0, 2).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          {/* Admin crown indicator */}
-          {client.isAdmin && (
-            <div className="absolute -top-0.5 -right-0.5 bg-yellow-500 rounded-full p-0.5">
-              <Crown
-                className="h-2.5 w-2.5 text-yellow-900"
-                fill="currentColor"
-              />
-            </div>
-          )}
-        </div>
-        <div className="flex flex-col min-w-0">
-          <span className="text-xs font-medium truncate">
-            {client.username}
-          </span>
-        </div>
-        <Badge
-          variant={isCurrentUser ? "default" : "outline"}
-          className={cn(
-            "ml-auto text-xs shrink-0 min-w-[60px] text-center py-0 h-5",
-            isCurrentUser ? "bg-primary-600 text-primary-50" : ""
-          )}
-        >
-          {isCurrentUser ? "You" : "Connected"}
-        </Badge>
-        {/* Admin controls dropdown - only show if current user is admin and not targeting self */}
-        {isAdmin && !isCurrentUser && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 w-6 p-0 hover:bg-neutral-700/50"
-              >
-                <MoreVertical className="h-3 w-3" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
-              {client.isAdmin ? (
-                <DropdownMenuItem
-                  onClick={() => onSetAdmin(client.clientId, false)}
-                  className="text-xs"
-                >
-                  <Crown className="h-3 w-3 mr-2 text-red-500" />
-                  Remove Admin
-                </DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem
-                  onClick={() => onSetAdmin(client.clientId, true)}
-                  className="text-xs"
-                >
-                  <Crown className="h-3 w-3 mr-2 text-green-500" />
-                  Make Admin
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-      </motion.div>
-    );
-  }
-);
-
-ConnectedUserItem.displayName = "ConnectedUserItem";
 
 export const UserGrid = () => {
   const userId = useRoomStore((state) => state.userId);
@@ -440,13 +328,6 @@ export const UserGrid = () => {
     });
   }, [clients, userId]);
 
-  const reorderClient = useGlobalStore((state) => state.reorderClient);
-  const setAdminStatus = useGlobalStore((state) => state.setAdminStatus);
-
-  // Get current user from global store
-  const currentUser = useGlobalStore((state) => state.currentUser);
-  const isCurrentUserAdmin = currentUser?.isAdmin || false;
-
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3">
@@ -553,33 +434,6 @@ export const UserGrid = () => {
             {/* Gain Meter */}
             <div className="mb-3 mt-2.5">
               <GainMeter />
-            </div>
-
-            {/* Add big move up button for current user only */}
-            <div className="flex mb-4 justify-end">
-              <Button
-                className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer"
-                size="sm"
-                onClick={() => reorderClient(userId)}
-              >
-                <ArrowUp className="size-4" /> Move to Top
-              </Button>
-            </div>
-
-            {/* List of connected users - Constrained height */}
-            <div className="relative">
-              <div className="space-y-1 overflow-y-auto flex-shrink-0 scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent hover:scrollbar-thumb-muted-foreground/20">
-                {clientsWithData.map(({ client, isCurrentUser }) => (
-                  <ConnectedUserItem
-                    key={client.clientId}
-                    client={client}
-                    isCurrentUser={isCurrentUser}
-                    isAdmin={isCurrentUserAdmin}
-                    onSetAdmin={setAdminStatus}
-                  />
-                ))}
-              </div>
-              {/* <div className="absolute -top-0.5 left-0 right-0 h-2 bg-gradient-to-b from-neutral-900 to-transparent pointer-events-none"></div> */}
             </div>
           </>
         )}

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -78,9 +78,9 @@ const ClientAvatar = memo<ClientAvatarProps>(
               )}
               {/* Admin crown indicator */}
               {client.isAdmin && (
-                <div className="absolute -top-0.5 -right-0.5 bg-yellow-500 rounded-full p-0.5">
+                <div className="absolute -top-0 -right-0 bg-yellow-500 rounded-full p-0.5">
                   <Crown
-                    className="h-3 w-3 text-yellow-900"
+                    className="h-2.5 w-2.5 text-yellow-900"
                     fill="currentColor"
                   />
                 </div>
@@ -329,7 +329,7 @@ export const UserGrid = () => {
   }, [clients, userId]);
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex flex-col overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3">
         <div className="flex items-center gap-2 font-medium">
           <Rotate3D size={18} />
@@ -432,7 +432,7 @@ export const UserGrid = () => {
             </div>
 
             {/* Gain Meter */}
-            <div className="mb-3 mt-2.5">
+            <div className="mt-2.5">
               <GainMeter />
             </div>
           </>

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
+import { useClientId } from "@/hooks/useClientId";
 import { cn } from "@/lib/utils";
 import { useCanMutate, useGlobalStore } from "@/store/global";
-import { useRoomStore } from "@/store/room";
 import { ClientType, GRID } from "@beatsync/shared";
 import { ArrowUp, Crown, HeadphonesIcon, Rotate3D } from "lucide-react";
 import { motion } from "motion/react";
@@ -103,7 +103,7 @@ const ClientAvatar = memo<ClientAvatarProps>(
 ClientAvatar.displayName = "ClientAvatar";
 
 export const UserGrid = () => {
-  const userId = useRoomStore((state) => state.userId);
+  const { clientId } = useClientId();
   const canMutate = useCanMutate();
   const listeningSource = useGlobalStore(
     (state) => state.listeningSourcePosition
@@ -327,10 +327,10 @@ export const UserGrid = () => {
   // Memoize client data to avoid unnecessary recalculations
   const clientsWithData = useMemo(() => {
     return clients.map((client) => {
-      const isCurrentUser = client.clientId === userId;
+      const isCurrentUser = client.clientId === clientId;
       return { client, isCurrentUser };
     });
-  }, [clients, userId]);
+  }, [clients, clientId]);
 
   return (
     <div className="flex flex-col overflow-hidden">
@@ -451,7 +451,7 @@ export const UserGrid = () => {
             className="text-xs px-3 py-1 h-auto bg-neutral-700/60 hover:bg-neutral-700 text-white transition-colors duration-200 cursor-pointer w-fit disabled:opacity-50 disabled:cursor-not-allowed"
             size="sm"
             disabled={!canMutate}
-            onClick={() => reorderClient(userId)}
+            onClick={() => reorderClient(clientId || "")}
           >
             <ArrowUp className="size-4" /> Move to Top
           </Button>

--- a/apps/client/src/components/room/UserGrid.tsx
+++ b/apps/client/src/components/room/UserGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { cn } from "@/lib/utils";
-import { useGlobalStore } from "@/store/global";
+import { useCanMutate, useGlobalStore } from "@/store/global";
 import { useRoomStore } from "@/store/room";
 import { ClientType, GRID } from "@beatsync/shared";
 import { Crown, HeadphonesIcon, Rotate3D } from "lucide-react";
@@ -103,6 +103,7 @@ ClientAvatar.displayName = "ClientAvatar";
 
 export const UserGrid = () => {
   const userId = useRoomStore((state) => state.userId);
+  const canMutate = useCanMutate();
   const listeningSource = useGlobalStore(
     (state) => state.listeningSourcePosition
   );
@@ -182,18 +183,20 @@ export const UserGrid = () => {
   // Handlers for dragging the listening source
   const handleSourceMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      if (!canMutate) return;
       e.stopPropagation(); // Prevent grid click handler from firing
       setIsDraggingListeningSource(true);
     },
-    [setIsDraggingListeningSource]
+    [canMutate, setIsDraggingListeningSource]
   );
 
   const handleSourceTouchStart = useCallback(
     (e: React.TouchEvent) => {
+      if (!canMutate) return;
       e.stopPropagation(); // Prevent grid touch handler from firing
       setIsDraggingListeningSource(true);
     },
-    [setIsDraggingListeningSource]
+    [canMutate, setIsDraggingListeningSource]
   );
 
   const handleSourceMouseUp = useCallback(() => {
@@ -338,6 +341,7 @@ export const UserGrid = () => {
           <Switch
             checked={isSpatialAudioEnabled}
             onCheckedChange={(checked) => {
+              if (!canMutate) return;
               setIsSpatialAudioEnabled(checked);
               if (checked) {
                 // When turning on, send current listening source position
@@ -346,6 +350,8 @@ export const UserGrid = () => {
                 stopSpatialAudio();
               }
             }}
+            disabled={!canMutate}
+            className={cn(!canMutate && "opacity-50")}
           />
         </div>
       </div>
@@ -381,18 +387,21 @@ export const UserGrid = () => {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <motion.div
-                      className="absolute z-40 cursor-move"
+                      className={cn(
+                        "absolute z-40",
+                        canMutate ? "cursor-move" : ""
+                      )}
                       style={{
                         left: `${listeningSource.x}%`,
                         top: `${listeningSource.y}%`,
                         transform: "translate(-50%, -50%)",
-                        opacity: isSpatialAudioEnabled ? 1 : 0.7,
+                        opacity: isSpatialAudioEnabled && canMutate ? 1 : 0.7,
                       }}
                       {...(!isDraggingListeningSource && {
                         animate: {
                           left: `${listeningSource.x}%`,
                           top: `${listeningSource.y}%`,
-                          opacity: isSpatialAudioEnabled ? 1 : 0.7,
+                          opacity: isSpatialAudioEnabled && canMutate ? 1 : 0.7,
                         },
                         transition: {
                           type: "tween",

--- a/apps/client/src/components/room/WebSocketManager.tsx
+++ b/apps/client/src/components/room/WebSocketManager.tsx
@@ -71,6 +71,9 @@ export const WebSocketManager = ({
   const handleSetAudioSources = useGlobalStore(
     (state) => state.handleSetAudioSources
   );
+  const setPlaybackControlsPermissions = useGlobalStore(
+    (state) => state.setPlaybackControlsPermissions
+  );
 
   // Use the NTP heartbeat hook
   const { startHeartbeat, stopHeartbeat, markNTPResponseReceived } =
@@ -155,6 +158,8 @@ export const WebSocketManager = ({
           setConnectedClients(event.clients);
         } else if (event.type === "SET_AUDIO_SOURCES") {
           handleSetAudioSources({ sources: event.sources });
+        } else if (event.type === "SET_PLAYBACK_CONTROLS") {
+          setPlaybackControlsPermissions(event.permissions);
         }
       } else if (response.type === "SCHEDULED_ACTION") {
         // handle scheduling action

--- a/apps/client/src/components/room/WebSocketManager.tsx
+++ b/apps/client/src/components/room/WebSocketManager.tsx
@@ -1,7 +1,8 @@
 "use client";
+import { useNtpHeartbeat } from "@/hooks/useNtpHeartbeat";
+import { useWebSocketReconnection } from "@/hooks/useWebSocketReconnection";
 import { useGlobalStore } from "@/store/global";
 import { useRoomStore } from "@/store/room";
-import { useNtpHeartbeat } from "@/hooks/useNtpHeartbeat";
 import { NTPMeasurement } from "@/utils/ntp";
 import {
   epochNow,
@@ -9,7 +10,6 @@ import {
   WSResponseSchema,
 } from "@beatsync/shared";
 import { useEffect } from "react";
-import { useWebSocketReconnection } from "@/hooks/useWebSocketReconnection";
 
 // Helper function for NTP response handling
 const handleNTPResponse = (response: NTPResponseMessageType) => {
@@ -134,6 +134,7 @@ export const WebSocketManager = ({
       scheduleReconnection();
     };
 
+    // TODO: Refactor into exhaustive handler registry
     ws.onmessage = async (msg) => {
       // Update last message received time for connection health
       useGlobalStore.setState({ lastMessageReceivedTime: Date.now() });

--- a/apps/client/src/hooks/useClientId.ts
+++ b/apps/client/src/hooks/useClientId.ts
@@ -1,33 +1,13 @@
-import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
-
-const CLIENT_ID_KEY = "beatsync-client-id";
+import { getClientId } from "@/lib/clientId";
 
 export function useClientId() {
   const [clientId, setClientId] = useState<string | null>(null);
 
   useEffect(() => {
-    let idToUse: string | null = null;
-    try {
-      // Check if we have an existing client ID in localStorage
-      const existingClientId = localStorage.getItem(CLIENT_ID_KEY);
-
-      if (existingClientId) {
-        idToUse = existingClientId;
-      } else {
-        // Generate a new client ID and save it
-        const newClientId = nanoid();
-        localStorage.setItem(CLIENT_ID_KEY, newClientId);
-        idToUse = newClientId;
-      }
-    } catch (error) {
-      console.error("Failed to access localStorage, generating non-persistent client ID:", error);
-      // Fallback: Generate a new client ID but don't persist it
-      // This allows the app to function, but the ID won't persist across sessions/reloads
-      idToUse = nanoid();
-    } finally {
-      setClientId(idToUse);
-    }
+    // Get the client ID using the shared logic
+    const id = getClientId();
+    setClientId(id);
   }, []);
 
   return { clientId };

--- a/apps/client/src/hooks/useClientId.ts
+++ b/apps/client/src/hooks/useClientId.ts
@@ -1,0 +1,34 @@
+import { nanoid } from "nanoid";
+import { useEffect, useState } from "react";
+
+const CLIENT_ID_KEY = "beatsync-client-id";
+
+export function useClientId() {
+  const [clientId, setClientId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let idToUse: string | null = null;
+    try {
+      // Check if we have an existing client ID in localStorage
+      const existingClientId = localStorage.getItem(CLIENT_ID_KEY);
+
+      if (existingClientId) {
+        idToUse = existingClientId;
+      } else {
+        // Generate a new client ID and save it
+        const newClientId = nanoid();
+        localStorage.setItem(CLIENT_ID_KEY, newClientId);
+        idToUse = newClientId;
+      }
+    } catch (error) {
+      console.error("Failed to access localStorage, generating non-persistent client ID:", error);
+      // Fallback: Generate a new client ID but don't persist it
+      // This allows the app to function, but the ID won't persist across sessions/reloads
+      idToUse = nanoid();
+    } finally {
+      setClientId(idToUse);
+    }
+  }, []);
+
+  return { clientId };
+}

--- a/apps/client/src/lib/clientId.ts
+++ b/apps/client/src/lib/clientId.ts
@@ -1,0 +1,41 @@
+import { nanoid } from "nanoid";
+
+const CLIENT_ID_KEY = "beatsync-client-id";
+
+let cachedClientId: string | null = null;
+
+/**
+ * Get or create a persistent client ID.
+ * This function can be called from anywhere (hooks, stores, etc.)
+ * and will always return the same ID for the session.
+ */
+export function getClientId(): string {
+  // Return cached value if we already have it
+  if (cachedClientId) {
+    return cachedClientId;
+  }
+
+  try {
+    // Check if we have an existing client ID in localStorage
+    const existingClientId = localStorage.getItem(CLIENT_ID_KEY);
+
+    if (existingClientId) {
+      cachedClientId = existingClientId;
+    } else {
+      // Generate a new client ID and save it
+      const newClientId = nanoid();
+      localStorage.setItem(CLIENT_ID_KEY, newClientId);
+      cachedClientId = newClientId;
+    }
+  } catch (error) {
+    console.error(
+      "Failed to access localStorage, generating non-persistent client ID:",
+      error
+    );
+    // Fallback: Generate a new client ID but don't persist it
+    // This allows the app to function, but the ID won't persist across sessions/reloads
+    cachedClientId = nanoid();
+  }
+
+  return cachedClientId;
+}

--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -29,7 +29,10 @@ export const extractFileNameFromUrl = (url: string) => {
   // Get everything after the last slash
   const parts = url.split("/");
   if (parts.length > 1) {
-    const fullFileName = parts[parts.length - 1];
+    const encodedFileName = parts[parts.length - 1];
+    
+    // Decode the URL-encoded filename to get the original characters
+    const fullFileName = decodeURIComponent(encodedFileName);
 
     // Extract the original filename by splitting on the delimiter
     // Format: originalName___timestamp.extension

--- a/apps/client/src/store/global.tsx
+++ b/apps/client/src/store/global.tsx
@@ -14,6 +14,8 @@ import {
   ClientType,
   GRID,
   NTP_CONSTANTS,
+  PlaybackControlsPermissionsEnum,
+  PlaybackControlsPermissionsType,
   PositionType,
   SpatialConfigType,
 } from "@beatsync/shared";
@@ -83,6 +85,9 @@ interface GlobalStateValues {
     currentAttempt: number;
     maxAttempts: number;
   };
+
+  // Playback controls
+  playbackControlsPermissions: PlaybackControlsPermissionsType;
 }
 
 interface GlobalState extends GlobalStateValues {
@@ -135,6 +140,9 @@ interface GlobalState extends GlobalStateValues {
     currentAttempt: number;
     maxAttempts: number;
   }) => void;
+  setPlaybackControlsPermissions: (
+    permissions: PlaybackControlsPermissionsType
+  ) => void;
 }
 
 // Define initial state values
@@ -182,6 +190,9 @@ const initialState: GlobalStateValues = {
     currentAttempt: 0,
     maxAttempts: 0,
   },
+
+  // Playback controls
+  playbackControlsPermissions: PlaybackControlsPermissionsEnum.enum.EVERYONE,
 };
 
 const getAudioPlayer = (state: GlobalState) => {
@@ -832,7 +843,8 @@ export const useGlobalStore = create<GlobalState>((set, get) => {
 
     setConnectedClients: (clients) => {
       const userId = useRoomStore.getState().userId;
-      const currentUser = clients.find(client => client.clientId === userId) || null;
+      const currentUser =
+        clients.find((client) => client.clientId === userId) || null;
       set({ connectedClients: clients, currentUser });
     },
 
@@ -990,5 +1002,7 @@ export const useGlobalStore = create<GlobalState>((set, get) => {
       initializeAudioExclusively();
     },
     setReconnectionInfo: (info) => set({ reconnectionInfo: info }),
+    setPlaybackControlsPermissions: (permissions) =>
+      set({ playbackControlsPermissions: permissions }),
   };
 });

--- a/apps/client/src/store/global.tsx
+++ b/apps/client/src/store/global.tsx
@@ -244,6 +244,18 @@ const initializeAudioContext = () => {
 
 const initializationMutex = new Mutex();
 
+// Selector for canMutate
+export const useCanMutate = () => {
+  const currentUser = useGlobalStore((state) => state.currentUser);
+  const playbackControlsPermissions = useGlobalStore(
+    (state) => state.playbackControlsPermissions
+  );
+  
+  const isAdmin = currentUser?.isAdmin || false;
+  const isEveryoneMode = playbackControlsPermissions === PlaybackControlsPermissionsEnum.enum.EVERYONE;
+  return isAdmin || isEveryoneMode;
+};
+
 export const useGlobalStore = create<GlobalState>((set, get) => {
   const processNewAudioSource = async ({ url }: AudioSourceType) => {
     console.log(`Processing new audio source ${url}`);

--- a/apps/client/src/store/global.tsx
+++ b/apps/client/src/store/global.tsx
@@ -250,9 +250,11 @@ export const useCanMutate = () => {
   const playbackControlsPermissions = useGlobalStore(
     (state) => state.playbackControlsPermissions
   );
-  
+
   const isAdmin = currentUser?.isAdmin || false;
-  const isEveryoneMode = playbackControlsPermissions === PlaybackControlsPermissionsEnum.enum.EVERYONE;
+  const isEveryoneMode =
+    playbackControlsPermissions ===
+    PlaybackControlsPermissionsEnum.enum.EVERYONE;
   return isAdmin || isEveryoneMode;
 };
 
@@ -395,7 +397,6 @@ export const useGlobalStore = create<GlobalState>((set, get) => {
         const { socket } = getSocket(state);
 
         // Request sync with room if conditions are met
-        console.log("Requesting sync from server for late joiner");
         sendWSRequest({
           ws: socket,
           request: { type: ClientActionEnum.enum.SYNC },

--- a/apps/client/src/store/room.tsx
+++ b/apps/client/src/store/room.tsx
@@ -5,14 +5,12 @@ import { create } from "zustand";
 interface RoomStateValues {
   roomId: string;
   username: string;
-  userId: string;
   isLoadingRoom: boolean;
 }
 
 interface RoomState extends RoomStateValues {
   setRoomId: (roomId: string) => void;
   setUsername: (username: string) => void;
-  setUserId: (userId: string) => void;
   setIsLoading: (isLoading: boolean) => void;
   reset: () => void;
 }
@@ -21,7 +19,6 @@ interface RoomState extends RoomStateValues {
 const initialState: RoomStateValues = {
   roomId: "",
   username: "",
-  userId: "",
   isLoadingRoom: false,
 };
 
@@ -32,7 +29,6 @@ export const useRoomStore = create<RoomState>()((set) => ({
   // Actions
   setRoomId: (roomId) => set({ roomId }),
   setUsername: (username) => set({ username }),
-  setUserId: (userId) => set({ userId }),
   setIsLoading: (isLoading) => set({ isLoadingRoom: isLoading }),
 
   // Reset to initial state

--- a/apps/server/src/managers/BackupManager.ts
+++ b/apps/server/src/managers/BackupManager.ts
@@ -53,6 +53,11 @@ export class BackupManager {
       // Restore audio sources
       room.setAudioSources(validAudioSources);
 
+      // Restore client cache if it exists (for backwards compatibility with older backups)
+      if (roomData.clientCache) {
+        room.restoreClientCache(roomData.clientCache);
+      }
+
       // Always schedule cleanup on restoration because we don't know if any clients will reconnect.
       globalManager.scheduleRoomCleanup(roomId);
       return {

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -155,6 +155,30 @@ export class RoomManager {
     // Reposition remaining clients if any
     if (this.clients.size > 0) {
       positionClientsInCircle(this.clients);
+
+      // Always check to ensure there is at least one admin
+
+      // Check if any admins remain after removing this client
+      const remainingAdmins = Array.from(this.clients.values()).filter(
+        (client) => client.isAdmin
+      );
+
+      // If no admins remain, randomly select a new admin
+      if (remainingAdmins.length === 0) {
+        const remainingClients = Array.from(this.clients.values());
+        const randomIndex = Math.floor(Math.random() * remainingClients.length);
+        const newAdmin = remainingClients[randomIndex];
+
+        if (newAdmin) {
+          newAdmin.isAdmin = true;
+          this.clients.set(newAdmin.clientId, newAdmin);
+          this.clientCache.set(newAdmin.clientId, { isAdmin: true });
+
+          console.log(
+            `✨ Automatically promoted ${newAdmin.username} (${newAdmin.clientId}) to admin in room ${this.roomId}`
+          );
+        }
+      }
     } else {
       // Stop heartbeat checking if no clients remain
       this.stopHeartbeatChecking();

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -119,14 +119,9 @@ export class RoomManager {
 
     // Check if this username has cached admin status
     const cachedClient = this.clientCache.get(username);
-    let isAdmin: boolean;
-    if (cachedClient) {
-      // Restore admin status from cache
-      isAdmin = cachedClient.isAdmin;
-    } else {
-      // The first client to join a room will always be an admin
-      isAdmin = this.clients.size === 0;
-    }
+
+    // The first client to join a room will always be an admin, otherwise they are an admin if they were an admin in the past
+    const isAdmin = cachedClient?.isAdmin || this.clients.size === 0;
 
     // Update the client cache
     this.clientCache.set(username, { isAdmin });

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -71,7 +71,7 @@ type RoomPlaybackState = z.infer<typeof RoomPlaybackStateSchema>;
  */
 export class RoomManager {
   private clients = new Map<string, ClientType>();
-  private clientCache = new Map<string, Pick<ClientType, "isAdmin">>();
+  private clientCache = new Map<string, Pick<ClientType, "isAdmin">>(); // user id -> isAdmin
   private audioSources: AudioSourceType[] = [];
   private listeningSource: PositionType = {
     x: GRID.ORIGIN_X,
@@ -118,13 +118,13 @@ export class RoomManager {
     const { username, clientId } = ws.data;
 
     // Check if this username has cached admin status
-    const cachedClient = this.clientCache.get(username);
+    const cachedClient = this.clientCache.get(clientId);
 
     // The first client to join a room will always be an admin, otherwise they are an admin if they were an admin in the past
     const isAdmin = cachedClient?.isAdmin || this.clients.size === 0;
 
     // Update the client cache
-    this.clientCache.set(username, { isAdmin });
+    this.clientCache.set(clientId, { isAdmin });
 
     // Add the new client
     this.clients.set(clientId, {
@@ -177,7 +177,7 @@ export class RoomManager {
     this.clients.set(targetClientId, client);
 
     // Update the client cache to remember this admin status
-    this.clientCache.set(client.username, { isAdmin });
+    this.clientCache.set(client.clientId, { isAdmin });
   }
 
   setPlaybackControls(

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -97,6 +97,10 @@ export class RoomManager {
     return this.roomId;
   }
 
+  getPlaybackControlsPermissions(): PlaybackControlsPermissionsType {
+    return this.playbackControlsPermissions;
+  }
+
   /**
    * Add a client to the room
    */

--- a/apps/server/src/routes/websocket.ts
+++ b/apps/server/src/routes/websocket.ts
@@ -1,5 +1,4 @@
 import { Server } from "bun";
-import { nanoid } from "nanoid";
 import { errorResponse } from "../utils/responses";
 import { WSData } from "../utils/websocket";
 
@@ -7,13 +6,15 @@ export const handleWebSocketUpgrade = (req: Request, server: Server) => {
   const url = new URL(req.url);
   const roomId = url.searchParams.get("roomId");
   const username = url.searchParams.get("username");
+  const clientId = url.searchParams.get("clientId");
 
-  if (!roomId || !username) {
+  if (!roomId || !username || !clientId) {
     // Check which parameters are missing and log them
     const missingParams = [];
 
     if (!roomId) missingParams.push("roomId");
     if (!username) missingParams.push("username");
+    if (!clientId) missingParams.push("clientId");
 
     console.log(
       `WebSocket connection attempt missing parameters: ${missingParams.join(
@@ -21,11 +22,10 @@ export const handleWebSocketUpgrade = (req: Request, server: Server) => {
       )}`
     );
 
-    return errorResponse("roomId and userId are required");
+    return errorResponse("roomId, username and clientId are required");
   }
 
-  const clientId = nanoid();
-  console.log(`User ${username} joined room ${roomId} with userId ${clientId}`);
+  console.log(`User ${username} joined room ${roomId} with clientId ${clientId}`);
 
   const data: WSData = {
     roomId,

--- a/apps/server/src/routes/websocketHandlers.ts
+++ b/apps/server/src/routes/websocketHandlers.ts
@@ -26,13 +26,7 @@ export const handleOpen = (ws: ServerWebSocket<WSData>, server: Server) => {
   console.log(
     `WebSocket connection opened for user ${ws.data.username} in room ${ws.data.roomId}`
   );
-  sendUnicast({
-    ws,
-    message: {
-      type: "SET_CLIENT_ID",
-      clientId: ws.data.clientId,
-    },
-  });
+  // Client already knows its ID from PostHog, no need to send SET_CLIENT_ID
 
   const { roomId } = ws.data;
   ws.subscribe(roomId);

--- a/apps/server/src/websocket/dispatch.ts
+++ b/apps/server/src/websocket/dispatch.ts
@@ -45,6 +45,9 @@ export async function dispatchMessage({
       server,
     });
   } catch (error) {
-    console.error(`[${ws.data.roomId}] Websocket handler threw error:"`, error);
+    console.error(
+      `[${ws.data.roomId}] Websocket handler ${handler.description} threw error:"`,
+      error
+    );
   }
 }

--- a/apps/server/src/websocket/handlers/handleSetPlaybackControls.ts
+++ b/apps/server/src/websocket/handlers/handleSetPlaybackControls.ts
@@ -1,10 +1,24 @@
 import { ExtractWSRequestFrom } from "@beatsync/shared";
+import { sendBroadcast } from "../../utils/responses";
 import { requireRoomAdmin } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handleSetPlaybackControls: HandlerFunction<
   ExtractWSRequestFrom["SET_PLAYBACK_CONTROLS"]
-> = async ({ ws, message }) => {
+> = async ({ ws, message, server }) => {
   const { room } = requireRoomAdmin(ws);
   room.setPlaybackControls(message.permissions);
+
+  // Echo
+  sendBroadcast({
+    server,
+    roomId: ws.data.roomId,
+    message: {
+      type: "ROOM_EVENT",
+      event: {
+        type: "SET_PLAYBACK_CONTROLS",
+        permissions: message.permissions,
+      },
+    },
+  });
 };

--- a/apps/server/src/websocket/handlers/pause.ts
+++ b/apps/server/src/websocket/handlers/pause.ts
@@ -1,13 +1,13 @@
 import { epochNow, ExtractWSRequestFrom } from "@beatsync/shared";
 import { SCHEDULE_TIME_MS } from "../../config";
 import { sendBroadcast } from "../../utils/responses";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handlePause: HandlerFunction<
   ExtractWSRequestFrom["PAUSE"]
 > = async ({ ws, message, server }) => {
-  const { room } = requireRoom(ws);
+  const { room } = requireCanMutate(ws);
 
   const serverTimeToExecute = epochNow() + SCHEDULE_TIME_MS;
 

--- a/apps/server/src/websocket/handlers/play.ts
+++ b/apps/server/src/websocket/handlers/play.ts
@@ -1,13 +1,13 @@
 import { epochNow, ExtractWSRequestFrom } from "@beatsync/shared";
 import { SCHEDULE_TIME_MS } from "../../config";
 import { sendBroadcast } from "../../utils/responses";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handlePlay: HandlerFunction<
   ExtractWSRequestFrom["PLAY"]
 > = async ({ ws, message, server }) => {
-  const { room } = requireRoom(ws);
+  const { room } = requireCanMutate(ws);
 
   const serverTimeToExecute = epochNow() + SCHEDULE_TIME_MS;
 

--- a/apps/server/src/websocket/handlers/reorderClient.ts
+++ b/apps/server/src/websocket/handlers/reorderClient.ts
@@ -1,13 +1,13 @@
 import { ExtractWSRequestFrom } from "@beatsync/shared";
 import { sendBroadcast } from "../../utils/responses";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handleReorderClient: HandlerFunction<
   ExtractWSRequestFrom["REORDER_CLIENT"]
 > = async ({ ws, message, server }) => {
   // Handle client reordering
-  const { room } = requireRoom(ws);
+  const { room } = requireCanMutate(ws);
 
   const reorderedClients = room.reorderClients(message.clientId, server);
 

--- a/apps/server/src/websocket/handlers/setListeningSource.ts
+++ b/apps/server/src/websocket/handlers/setListeningSource.ts
@@ -1,12 +1,12 @@
 import { ExtractWSRequestFrom } from "@beatsync/shared";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handleSetListeningSource: HandlerFunction<
   ExtractWSRequestFrom["SET_LISTENING_SOURCE"]
 > = async ({ ws, message, server }) => {
   // Handle listening source update
-  const { room } = requireRoom(ws);
+  const { room } = requireCanMutate(ws);
 
   room.updateListeningSource(message, server);
 };

--- a/apps/server/src/websocket/handlers/startSpatialAudio.ts
+++ b/apps/server/src/websocket/handlers/startSpatialAudio.ts
@@ -1,12 +1,12 @@
 import { ExtractWSRequestFrom } from "@beatsync/shared";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handleStartSpatialAudio: HandlerFunction<
   ExtractWSRequestFrom["START_SPATIAL_AUDIO"]
 > = async ({ ws, message, server }) => {
   // Start loop only if not already started
-  const { room } = requireRoom(ws); // do nothing if no room exists
+  const { room } = requireCanMutate(ws); // do nothing if no room exists
 
   room.startSpatialAudio(server);
 };

--- a/apps/server/src/websocket/handlers/stopSpatialAudio.ts
+++ b/apps/server/src/websocket/handlers/stopSpatialAudio.ts
@@ -4,12 +4,15 @@ import {
   epochNow,
 } from "@beatsync/shared";
 import { sendBroadcast } from "../../utils/responses";
-import { requireRoom } from "../middlewares";
+import { requireCanMutate } from "../middlewares";
 import { HandlerFunction } from "../types";
 
 export const handleStopSpatialAudio: HandlerFunction<
   ExtractWSRequestFrom["STOP_SPATIAL_AUDIO"]
 > = async ({ ws, message, server }) => {
+  // Stop the spatial audio interval if it exists
+  const { room } = requireCanMutate(ws); // do nothing if no room exists
+
   // This important for
   const broadcastMessage: WSBroadcastType = {
     type: "SCHEDULED_ACTION",
@@ -21,9 +24,6 @@ export const handleStopSpatialAudio: HandlerFunction<
 
   // Reset all gains:
   sendBroadcast({ server, roomId: ws.data.roomId, message: broadcastMessage });
-
-  // Stop the spatial audio interval if it exists
-  const { room } = requireRoom(ws); // do nothing if no room exists
 
   room.stopSpatialAudio();
 };

--- a/apps/server/src/websocket/middlewares.ts
+++ b/apps/server/src/websocket/middlewares.ts
@@ -44,7 +44,7 @@ export const requireRoomAdmin = (
 export const requireCanMutate = (
   ws: ServerWebSocket<WSData>
 ): { room: RoomManager } => {
-  const { room } = requireRoomAdmin(ws);
+  const { room } = requireRoom(ws);
   const client = room.getClient(ws.data.clientId);
   if (!client)
     throw new Error(

--- a/apps/server/src/websocket/middlewares.ts
+++ b/apps/server/src/websocket/middlewares.ts
@@ -1,3 +1,4 @@
+import { PlaybackControlsPermissionsEnum } from "@beatsync/shared";
 import { ServerWebSocket } from "bun";
 import { globalManager, RoomManager } from "../managers";
 import { WSData } from "../utils/websocket";
@@ -37,5 +38,28 @@ export const requireRoomAdmin = (
       `Client ${ws.data.clientId} is not an admin in room ${ws.data.roomId}`
     );
   }
+  return { room };
+};
+
+export const requireCanMutate = (
+  ws: ServerWebSocket<WSData>
+): { room: RoomManager } => {
+  const { room } = requireRoomAdmin(ws);
+  const client = room.getClient(ws.data.clientId);
+  if (!client)
+    throw new Error(
+      `Client ${ws.data.clientId} does not exist in room ${ws.data.roomId}`
+    );
+
+  const canMutate =
+    room.getPlaybackControlsPermissions() ===
+      PlaybackControlsPermissionsEnum.enum.EVERYONE || client.isAdmin;
+
+  if (!canMutate) {
+    throw new Error(
+      `Client ${ws.data.clientId} does not have permission to mutate in room ${ws.data.roomId}`
+    );
+  }
+
   return { room };
 };

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.477.0",
         "motion": "^12.9.2",
+        "nanoid": "^5.1.5",
         "next": "15.2.1",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.236.7",

--- a/packages/shared/types/WSBroadcast.ts
+++ b/packages/shared/types/WSBroadcast.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { PauseActionSchema, PlayActionSchema } from "./WSRequest";
+import {
+  PauseActionSchema,
+  PlayActionSchema,
+  SetPlaybackControlsSchema,
+} from "./WSRequest";
 import { AudioSourceSchema, PositionSchema } from "./basic";
 
 // ROOM EVENTS
@@ -32,6 +36,7 @@ const RoomEventSchema = z.object({
   event: z.discriminatedUnion("type", [
     ClientChangeMessageSchema,
     SetAudioSourcesSchema,
+    SetPlaybackControlsSchema,
   ]),
 });
 

--- a/packages/shared/types/WSRequest.ts
+++ b/packages/shared/types/WSRequest.ts
@@ -82,7 +82,7 @@ export type PlaybackControlsPermissionsType = z.infer<
   typeof PlaybackControlsPermissionsEnum
 >;
 
-const SetPlaybackControlsSchema = z.object({
+export const SetPlaybackControlsSchema = z.object({
   type: z.literal(ClientActionEnum.enum.SET_PLAYBACK_CONTROLS),
   permissions: PlaybackControlsPermissionsEnum,
 });

--- a/packages/shared/types/WSUnicast.ts
+++ b/packages/shared/types/WSUnicast.ts
@@ -10,14 +10,8 @@ const NTPResponseMessageSchema = z.object({
 });
 export type NTPResponseMessageType = z.infer<typeof NTPResponseMessageSchema>;
 
-const SetClientID = z.object({
-  type: z.literal("SET_CLIENT_ID"),
-  clientId: z.string(),
-});
-
 export const WSUnicastSchema = z.discriminatedUnion("type", [
   NTPResponseMessageSchema,
-  SetClientID,
   ScheduledActionSchema,
 ]);
 export type WSUnicastType = z.infer<typeof WSUnicastSchema>;


### PR DESCRIPTION
## Summary

Introduces an admin permissions system that allows controlling who can mutate playback state (play/pause, queue management, spatial audio). Admins can toggle
 between admin-only and everyone-can-control modes. The system includes persistent client IDs and automatic admin assignment when the last admin leaves.

## Changes

### Admin & Permissions System
- Add `canMutate` permission checks across audio controls, player, and queue components
- Implement `PlaybackPermissions` component for toggling control access
- Add `requireCanMutate` middleware for WebSocket handlers
- Restrict audio uploads to admins only

### Client Identity Management
- Implement persistent client IDs using nanoid stored in localStorage
- Add `useClientId` hook for consistent client identification
- Update RoomManager to cache admin status by client ID
- Restore admin status from backups for better UX

### UI Improvements
- Create `ConnectedUsersList` component with admin management UI
- Add crown icons to indicate admin users
- Refactor dashboard layout for better responsiveness
- Add dynamic viewport height utilities for mobile support
- Polish user grid with reorder functionality

### Backend Enhancements
- Add client cache to room backups
- Improve error logging with handler descriptions
- Fix admin assignment logic when last admin leaves
- Update WebSocket handlers to respect permissions

<img width="1512" height="851" alt="image" src="https://github.com/user-attachments/assets/4bb9ad31-6ab1-43c3-940d-c0230db0968d" />
