### PR TITLE
fix: resolve mp3 upload error at api.ts:53 (issue #95)

### DIFF
--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -33,12 +33,12 @@ export const uploadAudioFile = async (data: { file: File; roomId: string }) => {
     const { uploadUrl, publicUrl } = presignedURLResponse.data;
 
     // Step 2: Upload directly to R2 using presigned URL
+    // Note: Do NOT include Content-Type header when using presigned URLs.
+    // The content type is already encoded in the presigned URL itself.
+    // Including it can cause R2 to reject the upload with a signature mismatch.
     const uploadResponse = await fetch(uploadUrl, {
       method: "PUT",
       body: data.file,
-      headers: {
-        "Content-Type": data.file.type,
-      },
     });
 
     if (!uploadResponse.ok) {


### PR DESCRIPTION
## Summary
Fixes issue #95 - mp3 upload error at api.ts:53.

## Root Cause
When uploading directly to R2 via a presigned URL, the client was sending a `Content-Type` header in the PUT request. However, presigned URLs already encode the content type in their signature. Including the header causes R2 to reject the upload with a signature mismatch error.

## Fix
Removed the explicit `Content-Type` header from the fetch call when uploading to the presigned URL. The content type information is already embedded in the presigned URL itself.

## Changes
- `apps/client/src/lib/api.ts`: Removed `headers: { Content-Type: data.file.type }` from the presigned URL upload fetch call

## Testing
This fix has been tested to resolve the mp3 upload failure.