### PR TITLE
add per-client volume sync switch

### DIFF
--- a/apps/client/src/components/dashboard/GlobalVolumeControl.tsx
+++ b/apps/client/src/components/dashboard/GlobalVolumeControl.tsx
@@ -7,6 +7,7 @@ import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { throttle } from "throttle-debounce";
 import { Slider } from "../ui/slider";
+import { Switch } from "../ui/switch";
 
 interface GlobalVolumeControlProps {
   className?: string;
@@ -16,6 +17,8 @@ interface GlobalVolumeControlProps {
 export const GlobalVolumeControl = ({ className, isMobile = false }: GlobalVolumeControlProps) => {
   const canMutate = useCanMutate();
   const globalVolume = useGlobalStore((state) => state.globalVolume);
+  const syncVolume = useGlobalStore((state) => state.syncVolume);
+  const setSyncVolume = useGlobalStore((state) => state.setSyncVolume);
   const sendGlobalVolumeUpdate = useGlobalStore((state) => state.sendGlobalVolumeUpdate);
 
   // Local state for optimistic UI updates
@@ -155,6 +158,14 @@ export const GlobalVolumeControl = ({ className, isMobile = false }: GlobalVolum
               className={cn("flex-1", !canMutate && "opacity-50")}
             />
             <div className="text-xs text-neutral-400 min-w-[3rem] text-right">{Math.round(displayVolume * 100)}%</div>
+            <div className="flex items-center gap-1.5 ml-1">
+              <span className="text-[10px] text-neutral-500 uppercase font-bold tracking-tight select-none">Sync</span>
+              <Switch
+                checked={syncVolume}
+                onCheckedChange={setSyncVolume}
+                className="data-[state=checked]:bg-primary-500 [&_[data-slot=switch-thumb]]:bg-white scale-75"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -196,9 +207,14 @@ export const GlobalVolumeControl = ({ className, isMobile = false }: GlobalVolum
           className={cn("w-full", !canMutate && "opacity-50")}
         />
       </div>
-      {/* <div className="text-xs text-neutral-400 min-w-[2.5rem]">
-        {Math.round(isDragging ? localVolume : globalVolume * 100)}%
-      </div> */}
+      <div className="flex items-center gap-2 ml-1">
+        <span className="text-[10px] text-neutral-500 uppercase font-bold tracking-tight select-none">Sync</span>
+        <Switch
+          checked={syncVolume}
+          onCheckedChange={setSyncVolume}
+          className="data-[state=checked]:bg-primary-500 [&_[data-slot=switch-thumb]]:bg-white scale-75"
+        />
+      </div>
     </motion.div>
   );
 };

--- a/apps/client/src/store/global.tsx
+++ b/apps/client/src/store/global.tsx
@@ -124,6 +124,7 @@ interface GlobalStateValues {
   duration: number;
   volume: number;
   globalVolume: number; // Master volume (0-1)
+  syncVolume: boolean;
 
   // Tracking properties
   playbackStartTime: number;
@@ -202,6 +203,7 @@ interface GlobalState extends GlobalStateValues {
   getCurrentGainValue: () => number;
   getCurrentSpatialGainValue: () => number;
   setGlobalVolume: (volume: number) => void;
+  setSyncVolume: (syncVolume: boolean) => void;
   sendGlobalVolumeUpdate: (volume: number) => void;
   processGlobalVolumeConfig: (config: GlobalVolumeConfigType) => void;
   applyFinalGain: (rampTime?: number) => void;
@@ -280,6 +282,7 @@ const initialState: GlobalStateValues = {
   duration: 0,
   volume: 0.5,
   globalVolume: 1.0, // Default 100%
+  syncVolume: true,
   reconnectionInfo: {
     isReconnecting: false,
     currentAttempt: 0,
@@ -1379,8 +1382,28 @@ export const useGlobalStore = create<GlobalState>((set, get) => {
       get().applyFinalGain();
     },
 
+    setSyncVolume: (syncVolume) => {
+      set({ syncVolume });
+      if (syncVolume) {
+        const state = get();
+        try {
+          const { socket } = getSocket(state);
+          sendWSRequest({
+            ws: socket,
+            request: { type: ClientActionEnum.enum.SYNC },
+          });
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+
     sendGlobalVolumeUpdate: (volume) => {
       const state = get();
+      if (!state.syncVolume) {
+        get().setGlobalVolume(volume);
+        return;
+      }
       const { socket } = getSocket(state);
 
       sendWSRequest({
@@ -1393,6 +1416,7 @@ export const useGlobalStore = create<GlobalState>((set, get) => {
     },
 
     processGlobalVolumeConfig: (config: GlobalVolumeConfigType) => {
+      if (!get().syncVolume) return;
       const { volume, rampTime } = config;
       set({ globalVolume: volume });
       get().applyFinalGain(rampTime);

--- a/apps/server/src/managers/RoomManager.ts
+++ b/apps/server/src/managers/RoomManager.ts
@@ -913,6 +913,46 @@ export class RoomManager {
   }
 
   syncClient(ws: ServerWebSocket<WSData>): void {
+    const now = epochNow();
+
+    sendUnicast({
+      ws,
+      message: {
+        type: "SCHEDULED_ACTION",
+        serverTimeToExecute: now,
+        scheduledAction: {
+          type: "GLOBAL_VOLUME_CONFIG",
+          volume: this.globalVolume,
+          rampTime: 0.1,
+        },
+      },
+    });
+
+    sendUnicast({
+      ws,
+      message: {
+        type: "SCHEDULED_ACTION",
+        serverTimeToExecute: now,
+        scheduledAction: {
+          type: "METRONOME_CONFIG",
+          enabled: this.isMetronomeEnabled,
+        },
+      },
+    });
+
+    sendUnicast({
+      ws,
+      message: {
+        type: "SCHEDULED_ACTION",
+        serverTimeToExecute: now,
+        scheduledAction: {
+          type: "LOW_PASS_CONFIG",
+          freq: this.lowPassFreq,
+          rampTime: 0.05,
+        },
+      },
+    });
+
     // A client has joined late, and needs to sync with the room
     // Predict where the playback state will be after the dynamic scheduling delay
     // And make client play at that position then
@@ -924,7 +964,6 @@ export class RoomManager {
 
     const serverTimeWhenPlaybackStarted = this.playbackState.serverTimeToExecute;
     const trackPositionSecondsWhenPlaybackStarted = this.playbackState.trackPositionSeconds;
-    const now = epochNow();
 
     // Use dynamic scheduling based on max client RTT
     const serverTimeToExecute = this.getScheduledExecutionTime({


### PR DESCRIPTION
Adds a switch that lets users opt out of synced volume. When disabled, volume changes are local only and don't affect other users.